### PR TITLE
Fix issues when we don't want to echo the catpcha

### DIFF
--- a/src/Captcha.php
+++ b/src/Captcha.php
@@ -183,7 +183,7 @@ class Captcha
 
     public function __invoke($return = false)
     {
-        $this->refreshCaptcha($return);
+        return $this->refreshCaptcha($return);
     }
 
     public function __get($property)
@@ -202,7 +202,7 @@ class Captcha
         }
 
         // Return the Captcha Settings
-        if ($return) return $captcha;
+        if (!$return) return $captcha;
 
         echo $captcha['image'];
 


### PR DESCRIPTION
When we call for the captcha object, the __invoke method call the refreshCaptcha method but does not return the Array containing the created captcha.

If we don't want to echo the img tag, we have to pass 'false' parameter to the __invoke method, the test should be 'if(!$return)'.